### PR TITLE
Rewrite summarize-telemetry.js to not crash server

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "brfs": "^1.4.0",
     "browserify": "^14.0.0",
     "nodemon": "^1.2.1",
+    "run-parallel-limit": "^1.0.3",
     "standard": "*",
     "stylus": "^0.54.0",
     "watchify": "^3.1.2"


### PR DESCRIPTION
As the number of log files increases (one is created per day), the
amount of RAM required to run this script (which runs daily in a
cron-job) as increased.

The Promise.all() call just kicks off all file reads at the same time,
which uses a ton of resources. The webtorent.io server is configured to
restart when 100% RAM is used to prevent a common situation with
limited-RAM VPS servers where the swap file is used and thrashing
occurs, basically locking up the server.

I've noticed the server restarting itself once per day whenever this
cron job runs.

This rewrite just removes Promises (sorry!) and uses run-parallel-limit
to limit the concurrency to 5 tasks at a time. There's probably a
promise way to do this, but didn't want to figure it out right now.